### PR TITLE
#1484 preserve the order of custom attributes within the composed retrieval

### DIFF
--- a/Components/DLM/BExIS.Dlm.Services/Party/PartyManager.cs
+++ b/Components/DLM/BExIS.Dlm.Services/Party/PartyManager.cs
@@ -1122,7 +1122,7 @@ namespace BExIS.Dlm.Services.Party
             {
                 IRepository<PartyX> repo = uow.GetRepository<PartyX>();
                 //party = repo.Reload(party);
-                var mainValues = party.CustomAttributeValues.Where(item => item.CustomAttribute.IsMain).Select(item => item.Value).ToArray();
+                var mainValues = party.CustomAttributeValues.Where(item => item.CustomAttribute.IsMain).OrderBy(item => item.CustomAttribute.DisplayOrder).Select(item => item.Value).ToArray();
                 if (mainValues.Length > 0)
                 {
                     party.Name = string.Join(" ", mainValues); // what should happen when no custom attribute is there!?


### PR DESCRIPTION
... for "name" property (in case the party does not store/use. At least the order of the custom attributes will be the same as in the edit form. 